### PR TITLE
Add admin password

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This section will grow, as I'm designing each piece.
 logged in users.
 ### TODO
 
-**NEXT UP:** Make things pretty.
+**NEXT UP:** Error handling.
 
 1. Add login/auth. **DONE**
 2. Add logout. **DONE**

--- a/client/package.json
+++ b/client/package.json
@@ -3,6 +3,8 @@
     "version": "0.1.0",
     "private": true,
     "proxy": "http://localhost:5000",
+    "adminPrompt": "Speak friend and enter.",
+    "adminPassword": "friend",
     "scripts": {
         "start": "react-scripts start",
         "build": "react-scripts build",

--- a/client/src/routes/admin.jsx
+++ b/client/src/routes/admin.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { Form, useLoaderData } from 'react-router-dom'
+import { Form, Navigate, useLoaderData } from 'react-router-dom'
 import { Tab, Table } from 'semantic-ui-react'
+import packageJSON from '../../package.json'
 
 import AppButton from '../styleLibrary/AppButton'
 // import AppTab from '../styleLibrary/AppTab'
@@ -11,7 +12,10 @@ export async function loader() {
     return { users };
 }
 
-function Admin() {
+const Admin = () => {
+    // Only allow entry to /admin if the admin password is provided.
+    const adminPassword = prompt(packageJSON.adminPrompt)
+    const isPasswordCorrect = adminPassword === packageJSON.adminPassword
     const { users } = useLoaderData();
 
     const userList = users.map((user,index) => {
@@ -79,12 +83,12 @@ function Admin() {
         },
     ]
 
-    return (
+    return isPasswordCorrect ? (
         <div className="Admin">
             <h1>Hello Configuration</h1>
             <Tab panes={panes} />
         </div>
-    );
+    ) : ( <Navigate to='/' />)
 }
 
 export default Admin;

--- a/client/src/routes/admin.jsx
+++ b/client/src/routes/admin.jsx
@@ -14,6 +14,11 @@ export async function loader() {
 
 const Admin = () => {
     // Only allow entry to /admin if the admin password is provided.
+    //TODO: This is insecure!  Make this come from server.
+    // For right now, I'm only working on the UI, so this a placeholder for
+    // the real solution, which will be taht this will be in package.json
+    // on the server-side Node app (:5000) and we'll have to do a fetch
+    // to get this info.
     const adminPassword = prompt(packageJSON.adminPrompt)
     const isPasswordCorrect = adminPassword === packageJSON.adminPassword
     const { users } = useLoaderData();


### PR DESCRIPTION
If you go to `/admin`, it now asks for an admin password.  By default, this is 'friend'.  You can customize both the message (currently it's "speak friend and enter") and the password in package.json.

**NOTE:** Once I got to the backend, this should be in the backend package.json, instead.  The admin password should not be uploaded to the browser!  However, for now, since I'm doing the UI first, this is 