### PR TITLE
Wrap all SUI components used in wrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 - Less (forthcoming)
 ### TODO
 
-**NEXT UP:** Continue unit testing.
+**NEXT UP:** Tech Debt.
 
 1. Add login/auth. **DONE**
 2. Add logout. **DONE**

--- a/client/src/components/Notice.jsx
+++ b/client/src/components/Notice.jsx
@@ -1,10 +1,7 @@
 // This is an actual dismissable banner that shows a notice.
 import React from 'react'
-//TODO: Replace with AppMessage, when finished.
-import { Message as AppMessage } from 'semantic-ui-react'
 
-//TODO: This needs to be more robust to work.
-// import AppMessage from '../styleLibrary/AppMessage'
+import AppMessage from '../styleLibrary/AppMessage'
 
 const Notice = ({message, type, close = () => {} }) => {
     // NOTE: by convention type correponds to 

--- a/client/src/routes/admin.jsx
+++ b/client/src/routes/admin.jsx
@@ -1,9 +1,9 @@
 import React, { useContext } from 'react';
 import { Form, Navigate, useLoaderData } from 'react-router-dom'
-import { Tab, Table } from 'semantic-ui-react'
 
 import AppButton from '../styleLibrary/AppButton'
-// import AppTab from '../styleLibrary/AppTab'
+import AppTab from '../styleLibrary/AppTab'
+import AppTable from '../styleLibrary/AppTable'
 import { getUsers } from '../data/users.js'
 import { AdminContext } from '../contexts/AdminProvider'
 
@@ -23,10 +23,10 @@ const Admin = () => {
 
     const userList = users.map((user,index) => {
         return(
-            <Table.Row key={index}> 
-                <Table.Cell>{user.name || "<no name given>"}</Table.Cell>
-                <Table.Cell>{user.username || "<username left blank>"}</Table.Cell>
-                <Table.Cell>
+            <AppTable.Row key={index}> 
+                <AppTable.Cell>{user.name || "<no name given>"}</AppTable.Cell>
+                <AppTable.Cell>{user.username || "<username left blank>"}</AppTable.Cell>
+                <AppTable.Cell>
 
                     <Form 
                     style = {{display: 'inline'}}
@@ -52,36 +52,36 @@ const Admin = () => {
                         value="admin" />
                     </Form>
 
-                </Table.Cell>
-            </Table.Row>
+                </AppTable.Cell>
+            </AppTable.Row>
         )
     })
 
     const userTable = (
-        <Table size='small' striped compact celled selectable>
-            <Table.Header>
-                <Table.Row>
-                    <Table.HeaderCell>Name</Table.HeaderCell><Table.HeaderCell>username</Table.HeaderCell><Table.HeaderCell>Action</Table.HeaderCell>
-                </Table.Row>
-            </Table.Header>
-            <Table.Body>
+        <AppTable size='small' striped compact celled selectable>
+            <AppTable.Header>
+                <AppTable.Row>
+                    <AppTable.HeaderCell>Name</AppTable.HeaderCell><AppTable.HeaderCell>username</AppTable.HeaderCell><AppTable.HeaderCell>Action</AppTable.HeaderCell>
+                </AppTable.Row>
+            </AppTable.Header>
+            <AppTable.Body>
                 {userList}
-            </Table.Body>
-        </Table>
+            </AppTable.Body>
+        </AppTable>
     )
 
     const panes = [
         { 
             menuItem: 'Manage Users', render: () => (
-                <Tab.Pane>
+                <AppTab.Pane>
                     <h2>Users</h2>
                     {userTable}
-                </Tab.Pane>
+                </AppTab.Pane>
             )
         },
         { 
             menuItem: 'General Configuration', render: () => (
-                <Tab.Pane>TODO: This will hold general app config.</Tab.Pane> 
+                <AppTab.Pane>TODO: This will hold general app config.</AppTab.Pane> 
             ) 
         },
     ]
@@ -89,7 +89,7 @@ const Admin = () => {
     return (
         <div className="Admin">
             <h1>Hello Configuration</h1>
-            <Tab panes={panes} />
+            <AppTab panes={panes} />
         </div>
     )
 }

--- a/client/src/routes/editUser.jsx
+++ b/client/src/routes/editUser.jsx
@@ -5,13 +5,9 @@ import {
     redirect,
     useNavigate,
 } from "react-router-dom";
-// TODO: AppGrid fix wrapper under styleLibrary.  
-// Grid is multi-component, so will need more
-// handling than just a straight wrapper.
-import { Grid as AppGrid } from 'semantic-ui-react'
 
 import AppButton from '../styleLibrary/AppButton'
-// import AppGrid from '../styleLibrary/AppGrid'
+import AppGrid from '../styleLibrary/AppGrid'
 import AppInput from '../styleLibrary/AppInput'
 import { AuthContext } from '../contexts/AuthProvider'
 

--- a/client/src/routes/login.jsx
+++ b/client/src/routes/login.jsx
@@ -1,4 +1,3 @@
-// import { Form as AppForm } from 'semantic-ui-react'
 import React, { useContext, useState } from 'react'
 import { 
     useNavigate
@@ -9,7 +8,6 @@ import { AuthContext } from '../contexts/AuthProvider'
 import { useNotice } from '../contexts/NoticeProvider'
 import { validateUser } from '../data/users.js'
 
-//TODO: The line below isn't working, whereas the one above does.
 import AppForm from '../styleLibrary/AppForm'
 
 export default function Login() {

--- a/client/src/routes/login.jsx
+++ b/client/src/routes/login.jsx
@@ -1,4 +1,4 @@
-import { Form as AppForm } from 'semantic-ui-react'
+// import { Form as AppForm } from 'semantic-ui-react'
 import React, { useContext, useState } from 'react'
 import { 
     useNavigate
@@ -10,7 +10,7 @@ import { useNotice } from '../contexts/NoticeProvider'
 import { validateUser } from '../data/users.js'
 
 //TODO: The line below isn't working, whereas the one above does.
-// import AppForm from '../styleLibrary/AppForm'
+import AppForm from '../styleLibrary/AppForm'
 
 export default function Login() {
     const navigate = useNavigate()

--- a/client/src/routes/user.jsx
+++ b/client/src/routes/user.jsx
@@ -1,5 +1,3 @@
-// TODO: Use wrapper once I've successfully wrapped Grid.
-import { Grid as AppGrid } from 'semantic-ui-react'
 import React from 'react'
 import { 
     Form, 
@@ -9,7 +7,7 @@ import {
 import { getUser, updateUser } from "../data/users.js";
 
 import AppButton from '../styleLibrary/AppButton'
-// import AppGrid from '../styleLibrary/AppGrid'
+import AppGrid from '../styleLibrary/AppGrid'
 
 export async function action({ request, params }) {
     let formData = await request.formData();

--- a/client/src/styleLibrary/AppForm.jsx
+++ b/client/src/styleLibrary/AppForm.jsx
@@ -1,7 +1,20 @@
-import { Form as UIForm } from 'semantic-ui-react'
+import { Form } from 'semantic-ui-react'
 
-export default function AppForm(props){
+const AppForm = (props) => {
     return (
-        <UIForm {...props} />
+        <Form {...props} />
     )
 }
+
+AppForm.Button = (props) => (<Form.Button {...props} />)
+AppForm.Checkbox = (props) => (<Form.Checkbox {...props} />)
+AppForm.Dropdown = (props) => (<Form.Dropdown {...props} />)
+AppForm.Field = (props) => (<Form.Field {...props} />)
+AppForm.Group = (props) => (<Form.Group {...props} />)
+AppForm.Input = (props) => (<Form.Input {...props} />)
+AppForm.Radio = (props) => (<Form.Radio {...props} />)
+AppForm.Select = (props) => (<Form.Select {...props} />)
+AppForm.TextArea = (props) => (<Form.TextArea {...props} />)
+
+
+export default AppForm

--- a/client/src/styleLibrary/AppGrid.jsx
+++ b/client/src/styleLibrary/AppGrid.jsx
@@ -5,3 +5,6 @@ export default function AppGrid(props){
         <Grid {...props} />
     )
 }
+
+AppGrid.Column = (props) => (<Grid.Column {...props} />)
+AppGrid.Row = (props) => (<Grid.Row {...props} />)

--- a/client/src/styleLibrary/AppMessage.jsx
+++ b/client/src/styleLibrary/AppMessage.jsx
@@ -8,4 +8,9 @@ const AppMessage = (props) => {
     )
 }
 
+AppMessage.Content = (props) => (<Message.Content {...props} />)
+AppMessage.Header = (props) => (<Message.Header {...props} />)
+AppMessage.Item = (props) => (<Message.Item {...props} />)
+AppMessage.List = (props) => (<Message.List {...props} />)
+
 export default AppMessage

--- a/client/src/styleLibrary/AppTab.jsx
+++ b/client/src/styleLibrary/AppTab.jsx
@@ -5,3 +5,5 @@ export default function AppTab(props){
         <Tab {...props} />
     )
 }
+
+AppTab.Pane = (props) => (<Tab.Pane {...props} />)

--- a/client/src/styleLibrary/AppTable.jsx
+++ b/client/src/styleLibrary/AppTable.jsx
@@ -1,0 +1,14 @@
+import { Table } from 'semantic-ui-react'
+
+export default function AppTable(props){
+    return (
+        <Table {...props} />
+    )
+}
+
+AppTable.Body = (props) => (<Table.Body {...props} />)
+AppTable.Cell = (props) => (<Table.Cell {...props} />)
+AppTable.Footer = (props) => (<Table.Footer {...props} />)
+AppTable.Header = (props) => (<Table.Header {...props} />)
+AppTable.HeaderCell = (props) => (<Table.HeaderCell {...props} />)
+AppTable.Row = (props) => (<Table.Row {...props} />)


### PR DESCRIPTION
Going forward, all Semantic components must be wrapped in `styleLibrary` with the `App` prefix.  See `AppForm` for how to wrap sub-components.